### PR TITLE
Return upstream response info when blob cannot be pulled

### DIFF
--- a/importer/import.go
+++ b/importer/import.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedcom/harpoon/log"
 	"github.com/replicatedcom/harpoon/remote"
 
@@ -16,8 +17,7 @@ func init() {
 	var err error
 	dockerClient, err = docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
-		log.Error(err)
-		panic(err)
+		panic(errors.Wrap(err, "failed to create docker client"))
 	}
 }
 
@@ -51,8 +51,7 @@ func (i *Importer) ImportFromLocal(localStore *v1Store) error {
 		InputStream: archive,
 	}
 	if err = dockerClient.LoadImage(loadImageOptions); err != nil {
-		log.Error(err)
-		return err
+		return errors.Wrap(err, "failed to load image")
 	}
 
 	return nil

--- a/importer/pull_v1.go
+++ b/importer/pull_v1.go
@@ -6,5 +6,5 @@ import "errors"
 // ignore the cache if `force` is `true`.
 // TODO: Add auth info to args
 func (i *Importer) PullImageV1() (*v1Store, error) {
-	return nil, errors.New("pulling from v1 is not implemented")
+	return nil, errors.New("pulling from v1 registry is not implemented")
 }

--- a/proxy/pull_v2.go
+++ b/proxy/pull_v2.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
 	"github.com/replicatedcom/harpoon/log"
 	"github.com/replicatedcom/harpoon/remote"
 )
@@ -103,14 +104,12 @@ func (p *Proxy) GetManifestV2(namespace, imagename, ref string, accept []string)
 func (p *Proxy) GetBlobV2(namespace, imagename, digestFull string, additionalHeaders http.Header) (*BlobResponse, error) {
 	req, err := p.makeBlobRequest("GET", namespace, imagename, digestFull, additionalHeaders)
 	if err != nil {
-		log.Errorf("Failed to make proxied blob request for %s", req.URL.String())
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to make proxied blob request for %s", req.URL.String())
 	}
 
 	resp, err := p.Remote.DoWithRetry(req, 3)
 	if err != nil {
-		log.Errorf("Failed to do proxied blob request for %s", req.URL.String())
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to do proxied blob request for %s", req.URL.String())
 	}
 
 	return p.makeBlobResponse(resp, req.URL.String()), nil

--- a/requests/http_client.go
+++ b/requests/http_client.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -67,7 +69,7 @@ func newTransport(pemFilename, proxyAddress string) (*TcpTransport, error) {
 func (c *HttpClient) Get(url string) (*http.Response, error) {
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create request")
 	}
 	return c.Do(req)
 }
@@ -103,7 +105,7 @@ func (c *HttpClient) NewRequest(method, urlStr string, body io.Reader) (*http.Re
 			req.Header.Add(key, val)
 		}
 	}
-	return req, err
+	return req, errors.Wrap(err, "failed to create request")
 }
 
 func (c *HttpClient) Do(req *http.Request) (*http.Response, error) {

--- a/requests/transport.go
+++ b/requests/transport.go
@@ -54,13 +54,12 @@ func NewTlsTransport(pemFilename string) (*TcpTransport, error) {
 func replicatedCertPool(pemFilename string) (*x509.CertPool, error) {
 	file, err := ioutil.ReadFile(pemFilename)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read pem file %s", pemFilename)
 	}
 
 	roots := x509.NewCertPool()
 	if ok := roots.AppendCertsFromPEM(file); !ok {
-		err := errors.New("unable to append root cert")
-		return nil, err
+		return nil, errors.New("unable to append root cert")
 	}
 
 	return roots, nil

--- a/requests/transport.go
+++ b/requests/transport.go
@@ -3,10 +3,11 @@ package requests
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 // TODO: transport may be a misnomer


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/118143/docker-pull-fails-with-error-500-for-a-heritage-proxied-image

When upstream returns "Unauthorized", we need to pass that error back to client so it can authenticate again.